### PR TITLE
Remove inputs from question element

### DIFF
--- a/dist/entryPortal.html
+++ b/dist/entryPortal.html
@@ -36,7 +36,18 @@
     <tab-panel id="testPanel">
       <form-section
         header="Testing Page">
-        <text-area placeholder="Testing textarea" name="test"></text-area>
+        <form-question
+          id="sclshpTestingQuestion">
+          <label for="sclshpTestingInput">
+            <h3 slot="header">Testing Question</h3>
+          </label>
+          <drop-down
+            id="sclshpTestingInput"
+            placeholder="Testing selection...">
+            <option value="test1">Test 1</option>
+            <option value="test2">Test 2</option>
+          </drop-down>
+        </form-question>
       </form-section>
     </tab-panel>
 
@@ -48,12 +59,18 @@
         id="scholarshipAdminInfoForm">
 
         <form-question
-        label="Enter a title"
-        name="sclshpTitle"
-        type="text"
         id="sclshpTitleInput"
         required>
-        Scholarship Title
+          <label for="sclshpTitle">
+            <h3 slot="header">Scholarship Title</h3>
+          </label>
+          <outlined-text-field
+            id="sclshpTitleInput"
+            name="sclshpTitle"
+            type="text"
+            placeholder="Enter a title"
+            required>
+          </outlined-text-field>
         </form-question>
 
         <form-question

--- a/src/customElements/Dropdown.ts
+++ b/src/customElements/Dropdown.ts
@@ -108,7 +108,9 @@ export class Dropdown extends LitElement implements InputElement {
   @property({ type: Boolean, reflect: true }) required: boolean = false;
   @property({ type: Boolean, reflect: true }) disabled: boolean = false; // Added disabled property
   @property({ type: String }) value: string = ""; // Single value for each dropdown element
+  @property({ type: String }) name: string = ""; // Name of the dropdown element
   @property({ type: String, attribute: "error-message" }) accessor errorMessage: string = ""; // Public version, used to set the default error message
+  @property({ type: String }) placeholder: string = "Select an option"; // Placeholder text for the dropdown
 
   @state() accessor _hasChanged: boolean = false;
   @state() accessor _showError: boolean = false;
@@ -129,8 +131,8 @@ export class Dropdown extends LitElement implements InputElement {
   render() {
     return html`
       <div class="select-container ${classMap({ error: this._showError })}">
-        <select>
-          <option value="" disabled selected>Select a state</option>
+        <select name=${this.name}>
+          <option value="" disabled selected>${this.placeholder}</option>
         </select>
         <slot @slotchange="${this.handleSlotChange}"></slot>
       </div>

--- a/src/customElements/Forms.ts
+++ b/src/customElements/Forms.ts
@@ -8,6 +8,7 @@ import {
 } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { OutlinedTextField } from "./OutlinedTextField";
+import { InputElement } from "./InputElement";
 
 @customElement("form-question")
 export class FormQuestion extends LitElement {
@@ -27,30 +28,28 @@ export class FormQuestion extends LitElement {
   @property({ type: Boolean }) accessor required: boolean = false;
   @property({ type: String }) accessor label: string = "";
   @property({ type: Boolean }) accessor disabled: boolean = false;
-  @property({ type: String, attribute: "suffix-text" }) accessor suffixText =
-    "";
-  @property({ type: String, attribute: "prefix-text" }) accessor prefixText =
-    "";
-  // @property({type: String}) accessor value: string = "";
-  @property({ type: ElementInternals }) accessor internals: ElementInternals;
+  @property({ type: String, attribute: "suffix-text" }) accessor suffixText = "";
+  @property({ type: String, attribute: "prefix-text" }) accessor prefixText = "";
 
-  @query("outlined-text-field") private accessor _input: OutlinedTextField;
+  // Even though this returns an array, we will only ever use the first element
+  // that we find. Only one input element per question.
+  @queryAssignedElements() private accessor _inputList: InputElement[];
 
   constructor() {
     super();
-    this.internals = this.attachInternals();
   }
 
+  // Allows the form that this question is a part of to check the validity
+  // of the input.
   checkValidity(): boolean {
-    return this._input.checkValidity();
+    const input = this._inputList[0];
+    return input.checkValidity();
   }
 
-  set value(newValue: string) {
-    this._input.value = newValue;
-  }
-
-  get value() {
-    return this._input.value;
+  // Allows the form that this question is a part of to get the value of the input.
+  get value(): string {
+    const input = this._inputList[0];
+    return input.getValue();
   }
 
   protected render(): HTMLTemplateResult {
@@ -61,7 +60,7 @@ export class FormQuestion extends LitElement {
           <h3><slot name="header"></slot></h3>
         </label>
 
-        <!-- This will create a place for the chosen input -->
+        <!-- This is where our input element will go -->
         <slot></slot>
       </div>
     `;

--- a/src/customElements/Forms.ts
+++ b/src/customElements/Forms.ts
@@ -18,18 +18,9 @@ export class FormQuestion extends LitElement {
       flex-direction: column;
       margin: 10px;
       margin-bottom: 30px;
-      backrgound-color: inherit;
+      background-color: inherit;
     }
   `;
-
-  @property({ type: String }) accessor type: string = "";
-  @property({ type: String }) accessor name: string = "";
-  @property({ type: String }) accessor id: string = "";
-  @property({ type: Boolean }) accessor required: boolean = false;
-  @property({ type: String }) accessor label: string = "";
-  @property({ type: Boolean }) accessor disabled: boolean = false;
-  @property({ type: String, attribute: "suffix-text" }) accessor suffixText = "";
-  @property({ type: String, attribute: "prefix-text" }) accessor prefixText = "";
 
   // Even though this returns an array, we will only ever use the first element
   // that we find. Only one input element per question.
@@ -40,25 +31,22 @@ export class FormQuestion extends LitElement {
   }
 
   // Allows the form that this question is a part of to check the validity
-  // of the input.
+  // of the input. Really just shorthand for input.checkValidity().
   checkValidity(): boolean {
-    const input = this._inputList[0];
-    return input.checkValidity();
+    return this.input.checkValidity();
   }
 
-  // Allows the form that this question is a part of to get the value of the input.
-  get value(): string {
-    const input = this._inputList[0];
-    return input.getValue();
+  // Allows other elements to get an instance of the input element.
+  get input(): InputElement {
+    return this._inputList[0];
   }
 
   protected render(): HTMLTemplateResult {
     // This element MUST be used within a FormSection or HTMLFormElement.
     return html`
       <div>
-        <label for=${this.name}>
-          <h3><slot name="header"></slot></h3>
-        </label>
+        <!-- The label tag must be put in manually -->
+        <slot name="header"></slot>
 
         <!-- This is where our input element will go -->
         <slot></slot>
@@ -152,11 +140,8 @@ export class FormSection extends LitElement {
     console.log(`Got ${customQuestions.length} questions, printing values.`);
     for (let i = 0; i < customQuestions.length; i++) {
       const question = customQuestions[i];
-      console.log(`Found user input control: ${question}`);
-      console.log(`Assumed value: ${question.value}`);
-      console.log(`Question ID: ${question.name}`);
       // if (!input.reportValidity()) send = false;
-      formData.append(question.name, question.value);
+      formData.append(question.input.name, question.input.getValue());
     }
 
     console.log(
@@ -206,7 +191,7 @@ export class FormSection extends LitElement {
     this._questions.forEach((question) => {
       // Check validity of questions.
       if (!question.checkValidity()) {
-        console.log(`Question ${question.name} is not valid.`);
+        console.log(`Question ${question.input.name} is not valid.`);
         submittable = false;
       }
     });
@@ -219,7 +204,7 @@ export class FormSection extends LitElement {
     const formData = new FormData();
 
     this._questions.forEach((question) => {
-      formData.set(question.name, question.value);
+      formData.set(question.input.name, question.input.getValue());
     });
 
     fetch(this.action, {

--- a/src/customElements/Forms.ts
+++ b/src/customElements/Forms.ts
@@ -57,19 +57,12 @@ export class FormQuestion extends LitElement {
     // This element MUST be used within a FormSection or HTMLFormElement.
     return html`
       <div>
-        <label for=${this.name}
-          ><h3><slot></slot></h3
-        ></label>
-        <outlined-text-field
-          placeholder=${this.label}
-          ?disabled=${this.disabled}
-          ?required=${this.required}
-          name=${this.name}
-          suffix-text="${this.suffixText}"
-          prefix-text="${this.prefixText}"
-          type=${this.type}
-          id=${this.id}
-        ></outlined-text-field>
+        <label for=${this.name}>
+          <h3><slot name="header"></slot></h3>
+        </label>
+
+        <!-- This will create a place for the chosen input -->
+        <slot></slot>
       </div>
     `;
   }

--- a/src/customElements/InputElement.ts
+++ b/src/customElements/InputElement.ts
@@ -1,6 +1,7 @@
 export interface InputElement {
   required: boolean;
   disabled: boolean;
+  name: string;
 
   getValue(): string;
   checkValidity(): boolean;


### PR DESCRIPTION
Inputs were previously unable to have any element other than an `outlined-text-field`. This has been fixed.
To do this properly, I've added a new name field to the `InputElement` interface.

As a side effect, I also found a small bug in the `Dropdown` element which should be fixed.