### PR TITLE
Fix FormQuestion

### DIFF
--- a/dist/entryPortal.html
+++ b/dist/entryPortal.html
@@ -41,7 +41,6 @@
           id="sclshpTestingQuestion">
           <h3 slot="header">Testing Question</h3>
           <drop-down
-            slot="input"
             id="sclshpTestingInput"
             placeholder="Testing selection...">
             <option value="test1">Test 1</option>

--- a/dist/entryPortal.html
+++ b/dist/entryPortal.html
@@ -39,10 +39,9 @@
         header="Testing Page">
         <form-question
           id="sclshpTestingQuestion">
-          <label for="sclshpTestingInput">
-            <h3 slot="header">Testing Question</h3>
-          </label>
+          <h3 slot="header">Testing Question</h3>
           <drop-down
+            slot="input"
             id="sclshpTestingInput"
             placeholder="Testing selection...">
             <option value="test1">Test 1</option>
@@ -62,9 +61,7 @@
         <form-question
         id="sclshpTitleInput"
         required>
-          <label for="sclshpTitle">
-            <h3 slot="header">Scholarship Title</h3>
-          </label>
+          <h3 slot="header">Scholarship Title</h3>
           <outlined-text-field
             id="sclshpTitleInput"
             name="sclshpTitle"

--- a/src/customElements/Forms.ts
+++ b/src/customElements/Forms.ts
@@ -24,10 +24,21 @@ export class FormQuestion extends LitElement {
 
   // Even though this returns an array, we will only ever use the first element
   // that we find. Only one input element per question.
-  @queryAssignedElements() private accessor _inputList: InputElement[];
+  @queryAssignedElements({ slot: "input" }) accessor _inputList!: Array<InputElement>;
+
+  // After render, for accessibility, we want to set the label's "for" attribute
+  @query("label") private accessor _label!: HTMLLabelElement;
+
+  @state() private accessor inputID: string = "";
 
   constructor() {
     super();
+
+    // Wait for shadow root to render before setting up the label element.
+    // Use this.updateComplete
+    this.updateComplete.then(() => {
+      this._label.setAttribute("for", this.input.id);
+    });
   }
 
   // Allows the form that this question is a part of to check the validity
@@ -45,11 +56,18 @@ export class FormQuestion extends LitElement {
     // This element MUST be used within a FormSection or HTMLFormElement.
     return html`
       <div>
-        <!-- The label tag must be put in manually -->
-        <slot name="header"></slot>
+        <!-- Headers should be contained here. -->
+        <label>
+          <slot name="header">
+            <h2>No question header found</h2>
+          </slot>
+        </label>
 
         <!-- This is where our input element will go -->
-        <slot></slot>
+        <!-- This is queried as the default slot. -->
+        <slot name="input">
+          <p>No input element found</p>
+        </slot>
       </div>
     `;
   }

--- a/src/customElements/Forms.ts
+++ b/src/customElements/Forms.ts
@@ -65,7 +65,7 @@ export class FormQuestion extends LitElement {
 
         <!-- This is where our input element will go -->
         <!-- This is queried as the default slot. -->
-        <slot name="input">
+        <slot>
           <p>No input element found</p>
         </slot>
       </div>

--- a/src/customElements/Forms.ts
+++ b/src/customElements/Forms.ts
@@ -29,8 +29,6 @@ export class FormQuestion extends LitElement {
   // After render, for accessibility, we want to set the label's "for" attribute
   @query("label") private accessor _label!: HTMLLabelElement;
 
-  @state() private accessor inputID: string = "";
-
   constructor() {
     super();
 

--- a/src/customElements/InputElement.ts
+++ b/src/customElements/InputElement.ts
@@ -2,6 +2,7 @@ export interface InputElement {
   required: boolean;
   disabled: boolean;
   name: string;
+  id: string;
 
   getValue(): string;
   checkValidity(): boolean;


### PR DESCRIPTION
This fixes a bug introduced from PR #63 which made it so a `FormQuestion` could not return an instance of the `InputElement` inside of it, nor could it get the value from it. This was due to the fact that it was returning a `label` element, which is required for form accessibility, since it was located higher in the DOM.

The label has been moved inside the `FormQuestion` shadow root, and automatically sets the `for` attribute upon full element rendering.