### PR TITLE
Add dropdown arrow

### DIFF
--- a/dist/entryPortal.html
+++ b/dist/entryPortal.html
@@ -58,8 +58,6 @@
           </check-box>
         </form-question>
 
-      <!-- <form-section
-        header="Testing Page">
         <form-question
           id="sclshpTestingQuestion">
           <h3 slot="header">Testing Question</h3>
@@ -70,7 +68,7 @@
             <option value="test2">Test 2</option>
           </drop-down>
         </form-question>
-      </form-section> -->
+
     </tab-panel>
     
     <!--Scholarship InfAormation-->

--- a/src/customElements/Dropdown.ts
+++ b/src/customElements/Dropdown.ts
@@ -42,7 +42,6 @@ export class Dropdown extends LitElement implements InputElement {
         transition:
           border-color 400ms ease,
           background-color 400ms ease;
-      }
     }
 
     select {
@@ -50,11 +49,16 @@ export class Dropdown extends LitElement implements InputElement {
       flex-grow: 1;
       border: none;
       padding: 2px 15px;
+      padding: 2px 15px 2px 40px;
       color: #696158;
       border-radius: 8px;
       background-color: transparent;
       appearance: none;
       cursor: pointer;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath fill='%23696158' d='M7 10l5 5 5-5z'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: left 10px center;
+      background-size: 24px;
     }
 
     select:focus {
@@ -103,6 +107,8 @@ export class Dropdown extends LitElement implements InputElement {
         color: var(--theme-error-color);
       }
     }
+
+    
   `;
 
   @property({ type: Boolean, reflect: true }) required: boolean = false;


### PR DESCRIPTION
Added to 'select' of the 'select-container' CSS class to add an arrow symbol on the left side in the dropdown box. Visual cue makes it clear to the user that the box is a dropdown.