### PR TITLE
Add sticky tab header to page

### DIFF
--- a/dist/entryPortal.html
+++ b/dist/entryPortal.html
@@ -29,8 +29,13 @@
       font-family: 'Roboto', sans-serif;
     }
 
+    .banner-sticky {
+      position: sticky;
+      top: 0;
+      z-index: 999;
+    }
+
     .banner {
-      position: relative; /* Allows absolute positioning of the text box */
       height: 80px;
       background-color: var(--theme-primary-color); /* Dark red */
       display: flex;
@@ -87,33 +92,31 @@
     }
   </style>
   <body>
-  <div class="banner">
-    <div class="left-section">
-      <div class="logo left-logo">
-        <img src="images/PHS_Stacked_Acronym.png" alt="Left Logo">
+    <div class="banner-sticky">
+      <div class="banner">
+        <div class="left-section">
+          <div class="logo left-logo">
+            <img src="images/PHS_Stacked_Acronym.png" alt="Left Logo">
+          </div>
+          <div class="banner-text">
+            <h1>Scholarship Provider Form</h1>
+          </div>
+        </div>
+        <div class="text-box">
+          <h1>Submission Date: --/--/--</h1>
+        </div>
+        <div class="logo right-logo">
+          <img src="images/R15_logo_colorMatchWhite.png" alt="Right Logo">
+        </div>
       </div>
-      <div class="banner-text">
-        <h1>Scholarship Provider Form</h1>
-      </div>
+      <tab-bar>
+        <c-tab active panel-id="scholarshipInformationPanel">Scholarship Information</c-tab>
+        <c-tab panel-id="contactInformationPanel">Contact Information</c-tab>
+        <c-tab panel-id="eligibilityFactorsPanel">Eligibility Factors</c-tab>
+        <c-tab panel-id="studentRequirementsPanel">Student Requirements</c-tab>
+        <c-tab panel-id="test">test</c-tab>
+      </tab-bar>
     </div>
-    <div class="text-box">
-      <h1>Submission Date: --/--/--</h1>
-    </div>
-    <div class="logo right-logo">
-      <img src="images/R15_logo_colorMatchWhite.png" alt="Right Logo">
-    </div>
-  </div>
-  </body>
-
-<body>
-
-    <tab-bar>
-    <c-tab active panel-id="scholarshipInformationPanel">Scholarship Information</c-tab>
-    <c-tab panel-id="contactInformationPanel">Contact Information</c-tab>
-    <c-tab panel-id="eligibilityFactorsPanel">Eligibility Factors</c-tab>
-    <c-tab panel-id="studentRequirementsPanel">Student Requirements</c-tab>
-    <c-tab panel-id="test">test</c-tab>
-    </tab-bar>
 
     <tab-panel id="test">
       <form-section
@@ -195,11 +198,11 @@
                 "Maybe"]'>
           </check-box>
         </form-question>
-        
+
         <!--Checkbox test-->
         <form-question>
           <h3 slot="header">Checkbox Question</h3>
-          <check-box inputType="checkbox" 
+          <check-box inputType="checkbox"
             checkboxOptions='[
               "Option 1",
               "Option 2",
@@ -221,7 +224,7 @@
         </form-question>
       </form-section>
     </tab-panel>
-    
+
     <!--Scholarship InfAormation-->
     <tab-panel id="scholarshipInformationPanel">
 

--- a/dist/entryPortal.html
+++ b/dist/entryPortal.html
@@ -13,6 +13,7 @@
     <script src="./bundles/customElements.bundle.js" type="module"></script>
     <script src="./bundles/entryPortal.bundle.js" defer></script>
     <script src="./bundles/tabs.bundle.js" defer></script>
+    <script src="./bundles/stickyScrolling.bundle.js" defer></script>
   </head>
 
     <!--
@@ -33,6 +34,11 @@
       position: sticky;
       top: 0;
       z-index: 999;
+      transition: box-shadow 0.3s; /* Add shadow transition */
+      &.sticky-shadow {
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.6);  /* Add shadow when sticky */
+        transition: box-shadow 0.3s; /* Add shadow transition */
+      }
     }
 
     .banner {

--- a/src/scripts/stickyScrolling.js
+++ b/src/scripts/stickyScrolling.js
@@ -1,0 +1,22 @@
+$(function () {
+  // Check the initial position of the sticky header
+  $(window).on("scroll", () => {
+    // Just add a class to the header when we scroll down
+    if ($(window).scrollTop() > 0) {
+      $("banner-sticky").addClass("sticky-shadow");
+    }
+    // and remove it when we scroll up
+    else {
+      $("banner-sticky").removeClass("sticky-shadow");
+    }
+  });
+});
+
+
+window.onscroll = function() {
+  if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+    document.getElementsByClassName("banner-sticky").item(0).classList.add("sticky-shadow");
+  } else {
+    document.getElementsByClassName("banner-sticky").item(0).classList.remove("sticky-shadow");
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,13 @@ module.exports = {
         "./src/customElements/Checkbox.ts"
       ],
     },
+    stickyScrolling: {
+      import: "./src/scripts/stickyScrolling.js",
+      library: {
+        name: "Lib",
+        type: "var",
+      },
+    },
     index: {
       import: "./src/scripts/index.js",
       library: {


### PR DESCRIPTION
Wraps the banner and tab bar in `entryPortal.html` into a sticky `div`, which will keep the banner and tab at the top of the page while applicants scroll through.

This should probably be spun off into a custom `StickyBanner` object in the future.