### PR TITLE
Add small outlined text field

### DIFF
--- a/dist/providerLogin.html
+++ b/dist/providerLogin.html
@@ -69,10 +69,6 @@
         padding: 10px;
     }
 
-    .login-content {
-
-    }
-
     .register-text {
         margin-top: 10px;
         text-align: center;
@@ -130,8 +126,6 @@
     }
 </style>
 <body>
-
-
         <div class="login-container">
             <div class="banner">
                 <div class="left-section">
@@ -179,10 +173,45 @@
                     </div>
                 </div>
             </tab-panel>
+
+            <!-- Registration tab -->
+            <tab-panel id = "scholarshipProviderRegistrationPanel">
+
+                <form-question>
+                    <h3 slot="header"> Email </h3>
+                    <outlined-text-field
+                            label = "Email"
+                            placeholder = "Enter your email"
+                            type = "email"
+                            name = "sclshpProviderEmail"
+                    >
+                    </outlined-text-field>
+                </form-question>
+                <!-- Create password -->
+                <form-question>
+                    <h3 slot="header"> Password </h3>
+                    <outlined-text-field
+                            label = "Password"
+                            placeholder = "Enter your password"
+                            type = "password"
+                            name = "sclshpProviderPassword"
+                    >
+                    </outlined-text-field>
+                </form-question>
+                <!-- Confirm password -->
+                <form-question>
+                    <h3 slot="header"> Confirm password </h3>
+                    <outlined-text-field
+                            label = "confirmPassword"
+                            placeholder = "Enter your password again"
+                            type = "password"
+                            name = "sclshpProviderConfirmPassword"
+                    >
+                    </outlined-text-field>
+                </form-question>
+            </tab-panel>
         </div>
 
-
-
-
 </body>
+
 </html>

--- a/dist/providerLogin.html
+++ b/dist/providerLogin.html
@@ -14,7 +14,146 @@
     <script src="./bundles/tabs.bundle.js" defer></script>
     <!-- Create a login tab and a registration tab-->
 </head>
+<style>
+    @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+
+    :root {
+        --theme-primary-color: #980000;
+    }
+
+    body {
+        margin: 0;
+        font-family: 'Roboto', sans-serif;
+        background-color: white;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 90vh;
+    }
+
+    .login-container {
+        width: 400px;
+        height: 400px;
+        border-radius: 7px;
+        background-color: inherit;
+        box-shadow: 0 0 6px rgb(173, 170, 179);
+        overflow: hidden;
+    }
+
+    .banner {
+        position: relative;
+        height: 80px;
+        background-color: var(--theme-primary-color);
+        display: flex;
+        align-items: center;
+        padding: 5px 15px;
+    }
+
+    .left-section {
+        display: flex;
+        align-items: center;
+    }
+
+    .logo img {
+        width: 70px;
+        height: 70px;
+        object-fit: contain;
+        margin-right: 10px;
+        margin-top: 5px;
+    }
+
+    .banner-text h1 {
+        margin: 0;
+        font-size: 18px;
+        color: white;
+        padding: 10px;
+    }
+
+    .login-content {
+        padding: 20px;
+    }
+
+    .register-text {
+        margin-top: 10px;
+        text-align: center;
+        font-size: 14px;
+        color: #555;
+    }
+
+    .register-text a {
+        color: var(--theme-primary-color);
+        text-decoration: none;
+        font-weight: 700;
+    }
+
+    .register-text a:hover {
+        text-decoration: underline;
+    }
+
+    .login-content label {
+        display: block;
+        margin-bottom: 8px;
+        font-weight: 700;
+    }
+
+    .login-content input {
+        width: 100%;
+        padding: 10px;
+        margin-bottom: 20px;
+        border: 1px solid #ccc;
+        border-radius: 5px;
+        font-size: 16px;
+        box-sizing: border-box;
+    }
+
+    .login-button {
+        background-color: var(--theme-primary-color);
+        color: white;
+        border: none;
+        padding: 15px 0;
+        font-size: 16px;
+        border-radius: 30px;
+        cursor: pointer;
+        display: block;
+        width: 60%; /* Make the button longer */
+        margin: 20px auto 0; /* Center the button horizontally and add space at the top */
+        text-align: center;
+    }
+
+    .login-button:hover {
+        background-color: #7c0000;
+    }
+
+    .relative-wrapper {
+        position: relative;
+        height: 100%;
+    }
+</style>
 <body>
+<div class="login-container">
+    <div class="banner">
+        <div class="left-section">
+            <div class="logo">
+                <img src="images/PHS_Stacked_Acronym.png" alt="Logo">
+            </div>
+            <div class="banner-text">
+                <h1>Scholarship Provider Login</h1>
+            </div>
+        </div>
+    </div>
+    <div class="login-content">
+        <label for="username">Email</label>
+        <input type="text" id="username" placeholder="Enter your username">
+        <label for="password">Password</label>
+        <input type="password" id="password" placeholder="Enter your password">
+        <div class="register-text">
+            <span>Don't have an account? <a href="#">Click here to register</a></span>
+        </div>
+        <div class="relative-wrapper">
+            <button class="login-button">Sign in</button>
+        </div>
+    </div>
+</div>
 
 </body>
 </html>

--- a/dist/providerLogin.html
+++ b/dist/providerLogin.html
@@ -33,7 +33,7 @@
 
     .login-container {
         width: 400px;
-        height: 400px;
+        height: 500px;
         border-radius: 7px;
         background-color: inherit;
         box-shadow: 0 0 6px rgb(173, 170, 179);
@@ -130,30 +130,41 @@
     }
 </style>
 <body>
-<div class="login-container">
-    <div class="banner">
-        <div class="left-section">
-            <div class="logo">
-                <img src="images/PHS_Stacked_Acronym.png" alt="Logo">
+
+
+        <div class="login-container">
+            <div class="banner">
+                <div class="left-section">
+                    <div class="logo">
+                        <img src="images/PHS_Stacked_Acronym.png" alt="Logo">
+                    </div>
+                    <div class="banner-text">
+                        <h1>Scholarship Provider Login</h1>
+                    </div>
+                </div>
             </div>
-            <div class="banner-text">
-                <h1>Scholarship Provider Login</h1>
-            </div>
+            <tab-bar>
+                <c-tab active panel-id = "scholarshipProviderLoginPanel"> Sign on </c-tab>
+                <c-tab panel-id = "scholarshipProviderRegistrationPanel" > Register </c-tab>
+            </tab-bar>
+            <tab-panel id="scholarshipProviderLoginPanel">
+                <div class="login-content">
+                    <label for="username">Email</label>
+                    <input type="text" id="username" placeholder="Enter your username">
+                    <label for="password">Password</label>
+                    <input type="password" id="password" placeholder="Enter your password">
+                    <div class="register-text">
+                        <span>Don't have an account? <a href="#">Click here to register</a></span>
+                    </div>
+                    <div class="relative-wrapper">
+                        <button class="login-button">Sign in</button>
+                    </div>
+                </div>
+            </tab-panel>
         </div>
-    </div>
-    <div class="login-content">
-        <label for="username">Email</label>
-        <input type="text" id="username" placeholder="Enter your username">
-        <label for="password">Password</label>
-        <input type="password" id="password" placeholder="Enter your password">
-        <div class="register-text">
-            <span>Don't have an account? <a href="#">Click here to register</a></span>
-        </div>
-        <div class="relative-wrapper">
-            <button class="login-button">Sign in</button>
-        </div>
-    </div>
-</div>
+
+
+
 
 </body>
 </html>

--- a/dist/providerLogin.html
+++ b/dist/providerLogin.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
+    <script
+        src="https://code.jquery.com/jquery-3.7.1.min.js"
+        integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+        crossorigin="anonymous"></script>
+    <script src="./bundles/customElements.bundle.js" type="module"></script>
+    <script src="./bundles/entryPortal.bundle.js" defer></script>
+    <script src="./bundles/tabs.bundle.js" defer></script>
+    <!-- Create a login tab and a registration tab-->
+</head>
+<body>
+
+</body>
+</html>

--- a/dist/providerLogin.html
+++ b/dist/providerLogin.html
@@ -170,7 +170,7 @@
                     </form-question>
 
                     <div class="register-text">
-                        <span>Don't have an account? <a href="#">Click here to register</a></span>
+                        <span>Don't have an account? <a href="#" id="register-link">Click here to register</a></span>
                     </div>
                     <div class="relative-wrapper">
                         <button class="login-button">Sign in</button>
@@ -219,10 +219,25 @@
             </tab-panel>
         </div>
 
+
         <script>
-            // Get references to the tab-bar and container
+            // Get the register link, tab-bar element, and container
+            const registerLink = document.getElementById('register-link');
             const tabBar = document.querySelector('tab-bar');
             const loginContainer = document.querySelector('.login-container');
+
+            // Listen for the click event on the "Click here to register" link
+            registerLink.addEventListener('click', function(event) {
+                event.preventDefault();  // Prevent default anchor behavior
+
+                // Find the Register tab using the panel-id
+                const registerTab = [...tabBar.querySelectorAll('c-tab')].find(tab => tab.panelId === 'scholarshipProviderRegistrationPanel');
+
+                if (registerTab) {
+                    // Activate the Register tab via tabBar's API
+                    tabBar.activeTab = registerTab;  // This sets the active tab within the tab-bar
+                }
+            });
 
             // Listen for the tab change event
             tabBar.addEventListener('change', function() {

--- a/dist/providerLogin.html
+++ b/dist/providerLogin.html
@@ -28,16 +28,20 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        height: 90vh;
+        height: 100vh;
     }
 
     .login-container {
-        width: 600px;
-        height: 600px;
+        width: 500px;
+        max-width: 100%;
+        height: 600px; /* Default height for Login tab */
+        transition: height 0.3s ease-in-out; /* Smooth transition for height change */
         border-radius: 7px;
         background-color: inherit;
         box-shadow: 0 0 6px rgb(173, 170, 179);
         overflow: hidden;
+
+
     }
 
     .banner {
@@ -209,8 +213,31 @@
                     >
                     </outlined-text-field>
                 </form-question>
+                <div class="relative-wrapper">
+                    <button class="login-button"> Register </button>
+                </div>
             </tab-panel>
         </div>
+
+        <script>
+            // Get references to the tab-bar and container
+            const tabBar = document.querySelector('tab-bar');
+            const loginContainer = document.querySelector('.login-container');
+
+            // Listen for the tab change event
+            tabBar.addEventListener('change', function() {
+                const activeTab = tabBar.activeTab;  // Get the active tab
+
+                // Adjust container height based on the active tab
+                if (activeTab && activeTab.panelId === "scholarshipProviderLoginPanel") {
+                    // Set height to 600px for the Login tab
+                    loginContainer.style.height = "600px";
+                } else if (activeTab && activeTab.panelId === "scholarshipProviderRegistrationPanel") {
+                    // Set height to 700px for the Register tab
+                    loginContainer.style.height = "700px";
+                }
+            });
+        </script>
 
 </body>
 

--- a/dist/providerLogin.html
+++ b/dist/providerLogin.html
@@ -32,8 +32,8 @@
     }
 
     .login-container {
-        width: 400px;
-        height: 500px;
+        width: 600px;
+        height: 600px;
         border-radius: 7px;
         background-color: inherit;
         box-shadow: 0 0 6px rgb(173, 170, 179);
@@ -70,7 +70,7 @@
     }
 
     .login-content {
-        padding: 20px;
+
     }
 
     .register-text {
@@ -149,10 +149,28 @@
             </tab-bar>
             <tab-panel id="scholarshipProviderLoginPanel">
                 <div class="login-content">
-                    <label for="username">Email</label>
-                    <input type="text" id="username" placeholder="Enter your username">
-                    <label for="password">Password</label>
-                    <input type="password" id="password" placeholder="Enter your password">
+                    <form-question>
+                        <h3 slot="header"> Email </h3>
+                        <outlined-text-field
+                                label = "Email"
+                                placeholder = "Enter your email"
+                                type = "email"
+                                name = "sclshpProviderEmail"
+                        >
+                        </outlined-text-field>
+                    </form-question>
+
+                    <form-question>
+                        <h3 slot="header"> Password </h3>
+                        <outlined-text-field
+                                label = "Password"
+                                placeholder = "Enter your password"
+                                type = "password"
+                                name = "sclshpProviderPassword"
+                        >
+                        </outlined-text-field>
+                    </form-question>
+
                     <div class="register-text">
                         <span>Don't have an account? <a href="#">Click here to register</a></span>
                     </div>

--- a/src/customElements/TextField.ts
+++ b/src/customElements/TextField.ts
@@ -379,6 +379,7 @@ export class SmallOutlinedTextField extends OutlinedTextField {
       padding: 0 2px;
       display: flex;
       z-index: 2;
+      pointer-events: none;
     }
 
     input:focus ~ label,

--- a/src/customElements/TextField.ts
+++ b/src/customElements/TextField.ts
@@ -333,3 +333,86 @@ export class TextArea extends TextField {
     return this._textarea.checkValidity();
   }
 }
+
+@customElement("small-outlined-text-field")
+export class SmallOutlinedTextField extends OutlinedTextField {
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .container {
+      display: flex;
+      flex-direction: row;
+      border: 2px solid;
+      border-radius: 8px;
+      border-color: var(--theme-primary-color);
+      background-color: transparent;
+      margin-top: 2px;
+      height: 36px;
+      position: relative;
+      transition:
+        border-color 400ms ease,
+        background-color 400ms ease;
+    }
+
+    input {
+      font-family: inherit;
+      font-size: 10pt;
+      flex-grow: 1;
+      border: none;
+      padding: 0 10px;
+      color: #696158;
+      border-radius: 6px;
+      &:focus {
+        outline: none;
+      }
+    }
+
+    label {
+      font-size: 12pt;
+      position: absolute;
+      left: 10px;
+      top: 8px;
+      transition: all 0.1s ease;
+      background-color: transparent;
+      padding: 0 2px;
+      display: flex;
+      z-index: 2;
+    }
+
+    input:focus ~ label,
+    input:not(:placeholder-shown) ~ label {
+      top: -6px;
+      font-size: 10pt;
+      background-color: white;
+    }
+
+    .prefix,
+    .suffix {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      pointer-events: none;
+      font-size: 10pt;
+    }
+
+    .prefix {
+      margin-left: 8px;
+    }
+
+    .suffix {
+      margin-right: 8px;
+    }
+    
+    /* Changing the h3 header used to be uniform with the smaller text field
+       must be done within <styles></styles> in the html of the page. Custom 
+       element should be created in future for custom headers.
+       Following h3 redesign:
+        h3 {
+          margin: 0 0 4px 0;
+          padding: 8px 8px 8px 0;
+          font-size: 14pt; 
+          font-weight: bold; */
+  `;
+}


### PR DESCRIPTION
Added a smaller outlined text field option in the TextFIeld custom element. Extends the OutlinedTextField and changes only the CSS in order to keep the functionality of the text fields the same.

Changing the design of the h3 header used with the smaller text field element must be done within <styles></styles> in the html of the page.