### PR TITLE
Fix required essay prompts on requirements form

### DIFF
--- a/src/lambdaFunctions/updateScholarshipRequirements/index.ts
+++ b/src/lambdaFunctions/updateScholarshipRequirements/index.ts
@@ -16,43 +16,87 @@ export async function handler(event: AWSRequest): Promise<AWSResponse> {
   // console.log(`Found scholarship ID: ${scholarshipID}`);
 
   // Create a command to update everything that may be entered in the requirements form.
-  const command = new UpdateItemCommand({
-    TableName: "scholarship-info",
-    Key: {
-      ScholarshipID: {S: scholarshipID}
-    },
-    UpdateExpression: "SET #studentAidReport = :studentAidReport, #studentInterviews = :studentInterviews," +
-      "#recipientSelection = :recipientSelection, #transcriptRequirements = :transcriptRequirements," +
-      "#awardTo = :awardTo, " +
-      // "#sclshpReApplication = :sclshpReApplication," +
-      "#essayRequirement = :essayRequirement," +
-      "#essaySelection = :essaySelection, #awardNightRemarks = :awardNightRemarks," +
-      "#customEssayPrompt = :customEssayPrompt",
-    ExpressionAttributeValues: {
-      ":studentAidReport": {SS: JSON.parse(info.studentAidReport)},
-      ":studentInterviews": {SS: JSON.parse(info.studentInterviews)},
-      ":recipientSelection": {S: info.recipientSelection},
-      ":transcriptRequirements": {SS: JSON.parse(info.transcriptRequirements)},
-      ":awardTo": {SS: JSON.parse(info.awardTo)},
-      // ":sclshpReApplication": {SS: JSON.parse(info.scholarshipReApplication)},
-      ":essayRequirement": {SS: JSON.parse(info.essayRequirement)},
-      ":essaySelection": {SS: JSON.parse(info.essaySelection)},
-      ":awardNightRemarks": {S: info.awardNightRemarks},
-      ":customEssayPrompt": {S: info.customEssayPrompt}
-    },
-    ExpressionAttributeNames: {
-      "#studentAidReport": "studentAidReport",
-      "#studentInterviews": "studentInterviews",
-      "#recipientSelection": "recipientSelection",
-      "#transcriptRequirements": "transcriptRequirements",
-      "#awardTo": "awardTo",
-      // "#sclshpReApplication": "scholarshipReApplication",
-      "#essayRequirement": "essayRequirement",
-      "#essaySelection": "essaySelection",
-      "#awardNightRemarks": "awardNightRemarks",
-      "#customEssayPrompt": "customEssayPrompt"
-    }
-  });
+  let command: UpdateItemCommand;
+  if (info.essayRequirement === "Yes") {
+    command = new UpdateItemCommand({
+      TableName: "scholarship-info",
+      Key: {
+        ScholarshipID: {S: scholarshipID}
+      },
+      UpdateExpression: "SET #studentAidReport = :studentAidReport," +
+        "#studentInterviews = :studentInterviews," +
+        "#recipientSelection = :recipientSelection," +
+        "#transcriptRequirements = :transcriptRequirements," +
+        "#awardTo = :awardTo, " +
+        // "#sclshpReApplication = :sclshpReApplication," +
+        "#essayRequirement = :essayRequirement," +
+        "#essaySelection = :essaySelection," +
+        "#awardNightRemarks = :awardNightRemarks," +
+        "#customEssayPrompt = :customEssayPrompt",
+      ExpressionAttributeValues: {
+        ":studentAidReport": {SS: JSON.parse(info.studentAidReport)},
+        ":studentInterviews": {SS: JSON.parse(info.studentInterviews)},
+        ":recipientSelection": {S: info.recipientSelection},
+        ":transcriptRequirements": {SS: JSON.parse(info.transcriptRequirements)},
+        ":awardTo": {SS: JSON.parse(info.awardTo)},
+        // ":sclshpReApplication": {SS: JSON.parse(info.scholarshipReApplication)},
+        ":essayRequirement": {SS: JSON.parse(info.essayRequirement)},
+        ":essaySelection": {SS: JSON.parse(info.essaySelection)},
+        ":awardNightRemarks": {S: info.awardNightRemarks},
+        ":customEssayPrompt": {S: info.customEssayPrompt}
+      },
+      ExpressionAttributeNames: {
+        "#studentAidReport": "studentAidReport",
+        "#studentInterviews": "studentInterviews",
+        "#recipientSelection": "recipientSelection",
+        "#transcriptRequirements": "transcriptRequirements",
+        "#awardTo": "awardTo",
+        // "#sclshpReApplication": "scholarshipReApplication",
+        "#essayRequirement": "essayRequirement",
+        "#essaySelection": "essaySelection",
+        "#awardNightRemarks": "awardNightRemarks",
+        "#customEssayPrompt": "customEssayPrompt"
+      }
+    });
+  } else {
+    // Create a command to update everything that may be entered in the requirements form, except for the essay prompt
+    // and essay selection
+    console.log("Entering values without essay requirement");
+    command = new UpdateItemCommand({
+      TableName: "scholarship-info",
+      Key: {
+        ScholarshipID: { S: scholarshipID }
+      },
+      UpdateExpression: "SET #studentAidReport = :studentAidReport," +
+        "#studentInterviews = :studentInterviews," +
+        "#recipientSelection = :recipientSelection," +
+        "#transcriptRequirements = :transcriptRequirements," +
+        "#awardTo = :awardTo, " +
+        // "#sclshpReApplication = :sclshpReApplication," +
+        "#essayRequirement = :essayRequirement," +
+        "#awardNightRemarks = :awardNightRemarks",
+      ExpressionAttributeValues: {
+        ":studentAidReport": { SS: JSON.parse(info.studentAidReport) },
+        ":studentInterviews": { SS: JSON.parse(info.studentInterviews) },
+        ":recipientSelection": { S: info.recipientSelection },
+        ":transcriptRequirements": { SS: JSON.parse(info.transcriptRequirements) },
+        ":awardTo": { SS: JSON.parse(info.awardTo) },
+        // ":sclshpReApplication": {SS: JSON.parse(info.scholarshipReApplication)},
+        ":essayRequirement": { SS: JSON.parse(info.essayRequirement) },
+        ":awardNightRemarks": { S: info.awardNightRemarks }
+      },
+      ExpressionAttributeNames: {
+        "#studentAidReport": "studentAidReport",
+        "#studentInterviews": "studentInterviews",
+        "#recipientSelection": "recipientSelection",
+        "#transcriptRequirements": "transcriptRequirements",
+        "#awardTo": "awardTo",
+        // "#sclshpReApplication": "scholarshipReApplication",
+        "#essayRequirement": "essayRequirement",
+        "#awardNightRemarks": "awardNightRemarks"
+      }
+    });
+  }
 
   try {
     // Send the command

--- a/src/lambdaFunctions/updateScholarshipRequirements/index.ts
+++ b/src/lambdaFunctions/updateScholarshipRequirements/index.ts
@@ -11,13 +11,16 @@ const client = new DynamoDBClient({ region: "us-east-1" });
 export async function handler(event: AWSRequest): Promise<AWSResponse> {
   const info: ScholarshipRequirements = JSON.parse(event.body);
 
+  console.log(info);
+
   // Get the scholarship ID from the passed cookie
   const scholarshipID = event.headers.Cookie.match(/scholarshipID=([^;]*)/)[1];
   // console.log(`Found scholarship ID: ${scholarshipID}`);
 
   // Create a command to update everything that may be entered in the requirements form.
   let command: UpdateItemCommand;
-  if (info.essayRequirement === "Yes") {
+  if (info.essayRequirement === '["Yes"]') {
+    const essaySelection = (info.essaySelection === '[]') ? '["None"]' : info.essaySelection;
     command = new UpdateItemCommand({
       TableName: "scholarship-info",
       Key: {
@@ -41,7 +44,7 @@ export async function handler(event: AWSRequest): Promise<AWSResponse> {
         ":awardTo": {SS: JSON.parse(info.awardTo)},
         // ":sclshpReApplication": {SS: JSON.parse(info.scholarshipReApplication)},
         ":essayRequirement": {SS: JSON.parse(info.essayRequirement)},
-        ":essaySelection": {SS: JSON.parse(info.essaySelection)},
+        ":essaySelection": {SS: JSON.parse(essaySelection)},
         ":awardNightRemarks": {S: info.awardNightRemarks},
         ":customEssayPrompt": {S: info.customEssayPrompt}
       },

--- a/src/scripts/entryPortal.ts
+++ b/src/scripts/entryPortal.ts
@@ -8,12 +8,12 @@ $(async function () {
     const essayQuestion = $("#essaySelectionQuestion");
     const customEssayQuestion = $("#customEssayPromptQuestion");
     if (this.selectedCheckbox[0] === "Yes") {
-      // Show the box
-      essayQuestion.css("display","block");
+      // Show the questions
+      essayQuestion.css("display", "block");
       customEssayQuestion.css("display", "block");
     } else {
-      // Ensure the box is hidden
-      essayQuestion.css("display","none");
+      // Ensure the questions are hidden
+      essayQuestion.css("display", "none");
       customEssayQuestion.css("display", "none");
     }
   });

--- a/template.yaml
+++ b/template.yaml
@@ -379,12 +379,8 @@ Resources:
           KeyType: HASH
 #        - AttributeName: SampleKey
 #          KeyType: SORT
-      ProvisionedThroughput:
-        # This determines how many read and write requests we can take
-        # in a minute without throwing a rate error.
-        # If you don't know what that is, don't touch these.
-        ReadCapacityUnits: 300
-        WriteCapacityUnits: 150
+      # ALWAYS use PAY_PER_REQUEST for billing mode.
+      BillingMode: PAY_PER_REQUEST
   ScholarshipInfoTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -395,9 +391,7 @@ Resources:
       KeySchema:
         - AttributeName: ScholarshipID
           KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: 300
-        WriteCapacityUnits: 150
+      BillingMode: PAY_PER_REQUEST
 
   #Define the custom authorizer function
   providerAuthorizer:


### PR DESCRIPTION
Makes sure that the API only requires essays to be selected when the `essayRequirementInput` is Yes.

Also changes the DynamoDB tables to be `PAY_PER_REQUEST`, after being charged for unused provisioned capacity.