### PR TITLE
Redirect users to login if error 401 is thrown

### DIFF
--- a/src/scripts/entryPortal.ts
+++ b/src/scripts/entryPortal.ts
@@ -59,6 +59,10 @@ $(async function () {
       if (response.ok) {
         return response.json();
       } else {
+        if (response.status === 401) {
+          // If unauthorized, return user to the login page.
+          window.location.href = "/providerLogin.html";
+        }
         throw new Error(`HTTP Error ${response.status} - ${response.statusText}`);
       }
     })


### PR DESCRIPTION
Send users back to the login screen if the application detects an HTTP error 401 (Unauthorized). This will reduce confusion with expired tokens if users have bookmarked the provider entry portal page.