### PR TITLE
Add spacing above modal window

### DIFF
--- a/src/customElements/modalWindow.ts
+++ b/src/customElements/modalWindow.ts
@@ -48,7 +48,7 @@ export class ModalWindow extends LitElement {
       position: fixed;
       opacity: 0;
       pointer-events: none;
-      top: 0;
+      top: 50px;
       left: 0;
       height: 100vh;
       width: 100vw;


### PR DESCRIPTION
Moved the modal window down so that it wasn't up against the tab-bar when it was opened.