### PR TITLE
Fix typo in Post-Secondary education tab

### DIFF
--- a/dist/studentEntry.html
+++ b/dist/studentEntry.html
@@ -581,7 +581,7 @@
               id="universityStateInput"
               name="universityState"
               type="text"
-              placeholder="Enter the universities state">
+              placeholder="Enter the university's state">
           </outlined-text-field>
         </form-question>
 


### PR DESCRIPTION
Changed 'universities' to 'university's' in the placeholder of the University's State question.